### PR TITLE
Remove new line functionality on prepended card title

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -141,6 +141,10 @@ function createCard(id,title,task,counter = 2, completed) {
   </article>`);
 };
 
+$(document).on('keypress', 'h1', function(e){
+    return e.which != 13; 
+});   
+
 function saveCard() {
   event.preventDefault();
   var titleInput = $('#title-input').val();


### PR DESCRIPTION
Hey Parker,
Check out this code.
You can't hit enter on that card title anymore. Yeahhhhh!!!!!!